### PR TITLE
Allow for "minimal install" per Issue #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,25 @@ Your xmonad configuration must have the necessary gnome hooks in place.
 In practice things work perfectly if you are using `gnomeConfig` properly in
 your configuration.
 
+Minimal installation (doesn't install GHC)
+------------------------------------------
+
+Like the [Quick Installation](#quick-installation) above, except we avoid
+bringing in Ubuntu's GHC ecosystem:
+
+    sudo add-apt-repository ppa:gekkio/xmonad
+    sudo apt-get update
+    sudo apt-get install --no-install-recommends gnome-session-xmonad
+
+To be able to compile your `~/.xmonad/xmonad.hs`, you'll probably also want
+to install the X11 packages specified in the 
+[Xmonad README](https://github.com/xmonad/xmonad/blob/master/README.md#building):
+
+    sudo apt-get install libx11-dev libxinerama-dev libxext-dev libxft-dev libxrandr-dev libxss-dev
+
+This minimal installation assumes you already have GHC installed by some
+non-Apt means, e.g. via Stack or a http://haskell.org/ghc tarball.
+
 Supported Ubuntu versions
 -------------------------
 

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Package: gnome-session-xmonad
 Architecture: all
 Depends: gnome-session-flashback,
          xmonad (>= 0.11-9),
-         libghc-xmonad-contrib-dev (>= 0.11.3-3),
          ${misc:Depends}
+Recommends: libghc-xmonad-contrib-dev (>= 0.11.3-3)
 Description: GNOME Session Manager - XMonad session


### PR DESCRIPTION
See discussion in Issue #10.

I guess you'll want to cherry pick this to the other branches, changing the `libghc-xmonad-contrib-dev` version bounds as necessary.